### PR TITLE
Don't escape \n in secret dump

### DIFF
--- a/vault-dump.py
+++ b/vault-dump.py
@@ -64,9 +64,9 @@ def recurse_for_values(path_prefix, candidate_key):
                 sorted_final_keys = sorted(final_dict.keys())
                 for final_key in sorted_final_keys:
                     final_value = final_dict[final_key]
-                    print (" {0}={1}".format(final_key, repr(final_value)), end='')
+                    print (" {0}='{1}'".format(final_key, final_value), end='')
             else:
-                print("*** WARNING: no data for {}".format(repr(next_index)))
+                print("*** WARNING: no data for {}".format(next_index))
 
 
 env_vars = os.environ.copy()


### PR DESCRIPTION
Special symbols like `\n` are double escaped and secret value with newlines is not identical after restoration.

**How to reproduce:**
1. create secret 
```
vault write /secret/ssh-key key='-----BEGIN OPENSSH PRIVATE KEY-----
secret
-----END OPENSSH PRIVATE KEY-----
'
```

2. get secret
```
$ vault kv get -format=json  /secret/ssh-key
{
  "renewable": false,
  "data": {
    "key": "-----BEGIN OPENSSH PRIVATE KEY-----\nsecret\n-----END OPENSSH PRIVATE KEY-----\n"
  },
  "warnings": null
}
```

3. dump secret by vault-backup
```
$ TOP_VAULT_PREFIX=/secret/ssh-key/ python vault-dump.py                                                                                                                                                                               
#
# vault-dump.py backup
# dump made by vukor
# TOP_VAULT_PREFIX env variable: /secret/ssh-key/
# STDIN encoding: utf-8
# STDOUT encoding: utf-8
#
# WARNING: not guaranteed to be consistent!
#
vault write /secret/ssh-key key='-----BEGIN OPENSSH PRIVATE KEY-----\nsecret\n-----END OPENSSH PRIVATE KEY-----\n'
```

4. restore secret
```
$ vault write /secret/ssh-key key='-----BEGIN OPENSSH PRIVATE KEY-----\nsecret\n-----END OPENSSH PRIVATE KEY-----\n'
Success! Data written to: secret/ssh-key
```

5. get secret
```
$ vault kv get -format=json  /secret/ssh-key
{
  "renewable": false,
  "data": {
    "key": "-----BEGIN OPENSSH PRIVATE KEY-----\\nsecret\\n-----END OPENSSH PRIVATE KEY-----\\n"
  },
  "warnings": null
}
```

As you see it prints `\\n`. So in my use case, I've got the file with an incorrect SSH private key format.